### PR TITLE
Migrate XSVM to new API format

### DIFF
--- a/utils/lock/cond.go
+++ b/utils/lock/cond.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package lock
+
+import (
+	"context"
+	"sync"
+)
+
+// Cond implements a condition variable. Typically [sync.Cond] should be
+// preferred. However, this condition variable implementation supports
+// cancellable waits.
+type Cond struct {
+	L sync.Locker
+
+	m sync.Mutex // protects the waiters map
+	w map[chan struct{}]struct{}
+}
+
+// NewCond returns a new Cond with Locker l.
+func NewCond(l sync.Locker) *Cond {
+	return &Cond{
+		L: l,
+		w: make(map[chan struct{}]struct{}),
+	}
+}
+
+// Wait atomically unlocks c.L and suspends execution of the calling goroutine.
+// After later resuming execution, Wait locks c.L before returning. Unlike in
+// other systems, Wait cannot return unless awoken by [cond.Broadcast],
+// [cond.Signal], or due to the context being cancelled.
+//
+// Because c.L is not locked while Wait is waiting, the caller typically cannot
+// assume that the condition is true when Wait returns, even if the returned
+// value is nil. Instead, the caller should Wait in a loop:
+//
+//	c.L.Lock()
+//	defer c.L.Unlock()
+//
+//	for !condition() {
+//		if err := c.Wait(ctx); err != nil {
+//			return err
+//		}
+//	}
+//	... make use of condition ...
+func (c *Cond) Wait(ctx context.Context) error {
+	// Add this thread as a new waiter
+	c.m.Lock()
+	newL := make(chan struct{})
+	c.w[newL] = struct{}{}
+	c.m.Unlock()
+
+	c.L.Unlock()
+	// We must hold the lock when we return to ensure that the caller can
+	// release the lock after wait returns. This is true regardless of if the
+	// wait was cancelled or not.
+	defer c.L.Lock()
+
+	select {
+	case <-ctx.Done():
+		// Since the wait was cancelled, we remove our waiting channel on a
+		// best-effort basis.
+		c.m.Lock()
+		delete(c.w, newL)
+		c.m.Unlock()
+
+		return ctx.Err()
+	case <-newL:
+		return nil
+	}
+}
+
+// Signal wakes one goroutine waiting on c, if there is any.
+//
+// It is allowed but not required for the caller to hold c.L
+// during the call.
+//
+// Signal() does not affect goroutine scheduling priority; if other goroutines
+// are attempting to lock c.L, they may be awoken before a "waiting" goroutine.
+func (c *Cond) Signal() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for w := range c.w {
+		close(w)
+		delete(c.w, w)
+		break
+	}
+}
+
+// Broadcast wakes all goroutines waiting on c.
+//
+// It is allowed but not required for the caller to hold c.L
+// during the call.
+func (c *Cond) Broadcast() {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	for w := range c.w {
+		close(w)
+		delete(c.w, w)
+	}
+}

--- a/utils/lock/cond.go
+++ b/utils/lock/cond.go
@@ -9,8 +9,7 @@ import (
 )
 
 // Cond implements a condition variable. Typically [sync.Cond] should be
-// preferred. However, this condition variable implementation supports
-// cancellable waits.
+// preferred. However, this implementation supports cancellable waits.
 type Cond struct {
 	L sync.Locker
 
@@ -28,8 +27,8 @@ func NewCond(l sync.Locker) *Cond {
 
 // Wait atomically unlocks c.L and suspends execution of the calling goroutine.
 // After later resuming execution, Wait locks c.L before returning. Unlike in
-// other systems, Wait cannot return unless awoken by [cond.Broadcast],
-// [cond.Signal], or due to the context being cancelled.
+// other systems, Wait cannot return unless awoken by [Cond.Broadcast],
+// [Cond.Signal], or due to the context being cancelled.
 //
 // Because c.L is not locked while Wait is waiting, the caller typically cannot
 // assume that the condition is true when Wait returns, even if the returned
@@ -73,8 +72,7 @@ func (c *Cond) Wait(ctx context.Context) error {
 
 // Signal wakes one goroutine waiting on c, if there is any.
 //
-// It is allowed but not required for the caller to hold c.L
-// during the call.
+// It is allowed but not required for the caller to hold c.L during the call.
 //
 // Signal() does not affect goroutine scheduling priority; if other goroutines
 // are attempting to lock c.L, they may be awoken before a "waiting" goroutine.
@@ -91,8 +89,7 @@ func (c *Cond) Signal() {
 
 // Broadcast wakes all goroutines waiting on c.
 //
-// It is allowed but not required for the caller to hold c.L
-// during the call.
+// It is allowed but not required for the caller to hold c.L during the call.
 func (c *Cond) Broadcast() {
 	c.m.Lock()
 	defer c.m.Unlock()

--- a/utils/lock/cond_test.go
+++ b/utils/lock/cond_test.go
@@ -1,0 +1,162 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package lock
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCond(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var (
+		noop      = func(*Cond) {}
+		signal    = (*Cond).Signal
+		broadcast = (*Cond).Broadcast
+		merge     = func(ops ...func(*Cond)) func(*Cond) {
+			return func(c *Cond) {
+				for _, op := range ops {
+					op(c)
+				}
+			}
+		}
+		tests = []struct {
+			name           string
+			ctx            context.Context
+			expectedErrors []error
+			next           []func(*Cond)
+		}{
+			{
+				name:           "signal_once",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 1),
+				next: []func(*Cond){
+					signal,
+				},
+			},
+			{
+				name:           "signal_twice",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 1),
+				next: []func(*Cond){
+					merge(
+						signal,
+						signal,
+					),
+				},
+			},
+			{
+				name:           "signal_both_once",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 2),
+				next: []func(*Cond){
+					signal,
+					signal,
+				},
+			},
+			{
+				name:           "signal_both_once_atomically",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 2),
+				next: []func(*Cond){
+					merge(
+						signal,
+						signal,
+					),
+					noop,
+				},
+			},
+			{
+				name:           "broadcast_once",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 2),
+				next: []func(*Cond){
+					broadcast,
+					noop,
+				},
+			},
+			{
+				name:           "broadcast_twice",
+				ctx:            context.Background(),
+				expectedErrors: make([]error, 2),
+				next: []func(*Cond){
+					broadcast,
+					broadcast,
+				},
+			},
+			{
+				name: "cancelled",
+				ctx:  cancelled,
+				expectedErrors: []error{
+					context.Canceled,
+					context.Canceled,
+				},
+				next: []func(*Cond){
+					noop,
+					noop,
+				},
+			},
+		}
+		timeout = time.After(time.Second)
+	)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				require = require.New(t)
+				c       = NewCond(&sync.Mutex{})
+				errs    = make(chan error, len(test.expectedErrors))
+			)
+
+			for i := range test.expectedErrors {
+				// By grabbing the lock outside of the goroutine, we are ensured
+				// that all goroutines are waiting after this for loop exits
+				// once the lock is no longer held.
+				c.L.Lock()
+				go func() {
+					t.Log("waiting", i)
+					errs <- c.Wait(test.ctx)
+					t.Log("waited", i)
+					c.L.Unlock()
+				}()
+			}
+
+			c.L.Lock()
+			t.Log("synchronized waiters")
+			c.L.Unlock()
+
+			// All goroutines are waiting on the condition variable.
+
+			for i, next := range test.next {
+				t.Log("calling next", i)
+				next(c)
+				t.Log("called next", i)
+
+				select {
+				case err := <-errs:
+					require.ErrorIs(err, test.expectedErrors[i])
+					t.Log("checked error", i)
+
+				// Timing out rather than depending on the test timeout allows
+				// the logs to be printed rather than a stack trace.
+				case <-timeout:
+					t.Log("error checking timeout", i)
+					t.Fail()
+				}
+			}
+
+			// If the test has passed, this lock shouldn't be needed. But it is
+			// included to ensure the test doesn't panic if a timeout has fired.
+			c.m.Lock()
+			defer c.m.Unlock()
+
+			require.Empty(c.w)
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

This PR modifies the XSVM to return immediately when `WaitForEvent` is called and there are transactions available to the builder.

## How this works

This PR introduces a condition variable implementation that supports context cancellation. It then uses this implementation to modify the xsvm builder to implement `WaitForEvent`.

## How this was tested

- Added various unit tests for the condition variable implementation.
- Expected existing CI to ensure the XSVM is well tested.