### PR TITLE
Migrate PlatformVM to new API format

### DIFF
--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -94,6 +94,9 @@ func (b *builder) WaitForEvent(ctx context.Context) (common.Message, error) {
 
 		duration, err := b.durationToSleep()
 		if err != nil {
+			b.txExecutorBackend.Ctx.Log.Error("block builder failed to calculate next staker change time",
+				zap.Error(err),
+			)
 			return 0, err
 		}
 		if duration <= 0 {
@@ -113,7 +116,9 @@ func (b *builder) WaitForEvent(ctx context.Context) (common.Message, error) {
 		case errors.Is(err, context.DeadlineExceeded):
 			continue // Recheck the staker change time before returning
 		default:
-			return 0, err // Unexpected error
+			// Error could have been due to the parent context being cancelled
+			// or another unexpected error.
+			return 0, err
 		}
 	}
 }

--- a/vms/platformvm/block/builder/builder.go
+++ b/vms/platformvm/block/builder/builder.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -16,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -55,20 +55,6 @@ type Builder interface {
 	smblock.BuildBlockWithContextChainVM
 	mempool.Mempool[*txs.Tx]
 
-	// StartBlockTimer starts to issue block creation requests to advance the
-	// chain timestamp.
-	StartBlockTimer()
-
-	// ResetBlockTimer forces the block timer to recalculate when it should
-	// advance the chain timestamp.
-	ResetBlockTimer()
-
-	// ShutdownBlockTimer stops block creation requests to advance the chain
-	// timestamp.
-	//
-	// Invariant: Assumes the context lock is held when calling.
-	ShutdownBlockTimer()
-
 	// BuildBlock can be called to attempt to create a new block
 	BuildBlock(context.Context) (snowman.Block, error)
 
@@ -86,81 +72,50 @@ type builder struct {
 
 	txExecutorBackend *txexecutor.Backend
 	blkManager        blockexecutor.Manager
-
-	// resetTimer is used to signal that the block builder timer should update
-	// when it will trigger building of a block.
-	resetTimer chan struct{}
-	closed     chan struct{}
-	closeOnce  sync.Once
-	notify     func() // Notifies when a block is built
 }
 
 func New(
 	mempool mempool.Mempool[*txs.Tx],
 	txExecutorBackend *txexecutor.Backend,
 	blkManager blockexecutor.Manager,
-	notify func(),
 ) Builder {
 	return &builder{
-		notify:            notify,
 		Mempool:           mempool,
 		txExecutorBackend: txExecutorBackend,
 		blkManager:        blkManager,
-		resetTimer:        make(chan struct{}, 1),
-		closed:            make(chan struct{}),
 	}
 }
 
-func (b *builder) StartBlockTimer() {
-	go func() {
-		timer := time.NewTimer(0)
-		defer timer.Stop()
-
-		for {
-			// Invariant: The [timer] is not stopped.
-			select {
-			case <-timer.C:
-			case <-b.resetTimer:
-				if !timer.Stop() {
-					<-timer.C
-				}
-			case <-b.closed:
-				return
-			}
-
-			// Note: Because the context lock is not held here, it is possible
-			// that [ShutdownBlockTimer] is called concurrently with this
-			// execution.
-			for {
-				duration, err := b.durationToSleep()
-				if err != nil {
-					b.txExecutorBackend.Ctx.Log.Error("block builder encountered a fatal error",
-						zap.Error(err),
-					)
-					return
-				}
-
-				if duration > 0 {
-					timer.Reset(duration)
-					break
-				}
-
-				// Block needs to be issued to advance time.
-				b.notify()
-
-				// Invariant: ResetBlockTimer is guaranteed to be called after
-				// [durationToSleep] returns a value <= 0. This is because we
-				// are guaranteed to attempt to build block. After building a
-				// valid block, the chain will have its preference updated which
-				// may change the duration to sleep and trigger a timer reset.
-				select {
-				case <-b.resetTimer:
-				case <-b.closed:
-					return
-				}
-			}
+func (b *builder) WaitForEvent(ctx context.Context) (common.Message, error) {
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, err
 		}
-	}()
+
+		duration, err := b.durationToSleep()
+		if err != nil {
+			return 0, err
+		}
+		if duration <= 0 {
+			// The next staker change is ready to be performed.
+			return common.PendingTxs, nil
+		}
+
+		// Wait for a transaction in the mempool until there is a next staker
+		// change ready to be performed.
+		newCtx, cancel := context.WithTimeout(ctx, duration)
+		msg, err := b.Mempool.WaitForEvent(newCtx)
+		cancel()
+
+		switch {
+		case err == nil:
+			return msg, nil
+		case errors.Is(err, context.DeadlineExceeded):
+			continue // Recheck the staker change time before returning
+		default:
+			return 0, err // Unexpected error
+		}
+	}
 }
 
 func (b *builder) durationToSleep() (time.Duration, error) {
@@ -168,16 +123,6 @@ func (b *builder) durationToSleep() (time.Duration, error) {
 	// through modifying of the state.
 	b.txExecutorBackend.Ctx.Lock.Lock()
 	defer b.txExecutorBackend.Ctx.Lock.Unlock()
-
-	// If [ShutdownBlockTimer] was called, we want to exit the block timer
-	// goroutine. We check this with the context lock held because
-	// [ShutdownBlockTimer] is expected to only be called with the context lock
-	// held.
-	select {
-	case <-b.closed:
-		return 0, nil
-	default:
-	}
 
 	preferredID := b.blkManager.Preferred()
 	preferredState, ok := b.blkManager.GetState(preferredID)
@@ -199,20 +144,6 @@ func (b *builder) durationToSleep() (time.Duration, error) {
 	return nextStakerChangeTime.Sub(now), nil
 }
 
-func (b *builder) ResetBlockTimer() {
-	// Ensure that the timer will be reset at least once.
-	select {
-	case b.resetTimer <- struct{}{}:
-	default:
-	}
-}
-
-func (b *builder) ShutdownBlockTimer() {
-	b.closeOnce.Do(func() {
-		close(b.closed)
-	})
-}
-
 func (b *builder) BuildBlock(ctx context.Context) (snowman.Block, error) {
 	return b.BuildBlockWithContext(
 		ctx,
@@ -226,16 +157,6 @@ func (b *builder) BuildBlockWithContext(
 	ctx context.Context,
 	blockContext *smblock.Context,
 ) (snowman.Block, error) {
-	// If there are still transactions in the mempool, then we need to
-	// re-trigger block building.
-	defer func() {
-		if b.Mempool.Len() == 0 {
-			return
-		}
-
-		b.notify()
-	}()
-
 	b.txExecutorBackend.Ctx.Log.Debug("starting to attempt to build a block")
 
 	// Get the block to build on top of and retrieve the new block's context.

--- a/vms/platformvm/block/builder/builder_test.go
+++ b/vms/platformvm/block/builder/builder_test.go
@@ -157,7 +157,7 @@ func TestBuildBlockShouldReward(t *testing.T) {
 	require.Equal([]*txs.Tx{tx}, blk.(*blockexecutor.Block).Block.Txs())
 	require.NoError(blk.Verify(context.Background()))
 	require.NoError(blk.Accept(context.Background()))
-	require.True(env.blkManager.SetPreference(blk.ID()))
+	env.blkManager.SetPreference(blk.ID())
 
 	// Validator should now be current
 	staker, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
@@ -196,7 +196,7 @@ func TestBuildBlockShouldReward(t *testing.T) {
 		require.NoError(blk.Accept(context.Background()))
 		require.NoError(commit.Verify(context.Background()))
 		require.NoError(commit.Accept(context.Background()))
-		require.True(env.blkManager.SetPreference(commit.ID()))
+		env.blkManager.SetPreference(commit.ID())
 
 		// Stop rewarding once our staker is rewarded
 		if staker.TxID == txID {
@@ -454,15 +454,12 @@ func TestPreviouslyDroppedTxsCannotBeReAddedToMempool(t *testing.T) {
 }
 
 func TestNoErrorOnUnexpectedSetPreferenceDuringBootstrapping(t *testing.T) {
-	require := require.New(t)
-
 	env := newEnvironment(t, upgradetest.Latest)
 	env.ctx.Lock.Lock()
 	defer env.ctx.Lock.Unlock()
 
 	env.isBootstrapped.Set(false)
-
-	require.True(env.blkManager.SetPreference(ids.GenerateTestID())) // should not panic
+	env.blkManager.SetPreference(ids.GenerateTestID()) // should not panic
 }
 
 func TestGetNextStakerToReward(t *testing.T) {

--- a/vms/platformvm/block/builder/helpers_test.go
+++ b/vms/platformvm/block/builder/helpers_test.go
@@ -143,7 +143,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 	metrics, err := metrics.New(registerer)
 	require.NoError(err)
 
-	res.mempool, err = mempool.New("mempool", registerer, func() {})
+	res.mempool, err = mempool.New("mempool", registerer)
 	require.NoError(err)
 
 	res.blkManager = blockexecutor.NewManager(
@@ -169,7 +169,6 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		res.ctx.WarpSigner,
 		registerer,
 		config.DefaultNetwork,
-		func() {},
 	)
 	require.NoError(err)
 
@@ -177,9 +176,7 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 		res.mempool,
 		&res.backend,
 		res.blkManager,
-		func() {},
 	)
-	res.Builder.StartBlockTimer()
 
 	res.blkManager.SetPreference(genesisID)
 	addSubnet(t, res)
@@ -187,8 +184,6 @@ func newEnvironment(t *testing.T, f upgradetest.Fork) *environment { //nolint:un
 	t.Cleanup(func() {
 		res.ctx.Lock.Lock()
 		defer res.ctx.Lock.Unlock()
-
-		res.Builder.ShutdownBlockTimer()
 
 		if res.uptimes.StartedTracking() {
 			validatorIDs := res.config.Validators.GetValidatorIDs(constants.PrimaryNetworkID)

--- a/vms/platformvm/block/executor/executormock/manager.go
+++ b/vms/platformvm/block/executor/executormock/manager.go
@@ -133,11 +133,9 @@ func (mr *ManagerMockRecorder) Preferred() *gomock.Call {
 }
 
 // SetPreference mocks base method.
-func (m *Manager) SetPreference(blkID ids.ID) bool {
+func (m *Manager) SetPreference(blkID ids.ID) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPreference", blkID)
-	ret0, _ := ret[0].(bool)
-	return ret0
+	m.ctrl.Call(m, "SetPreference", blkID)
 }
 
 // SetPreference indicates an expected call of SetPreference.

--- a/vms/platformvm/block/executor/helpers_test.go
+++ b/vms/platformvm/block/executor/helpers_test.go
@@ -152,7 +152,7 @@ func newEnvironment(t *testing.T, ctrl *gomock.Controller, f upgradetest.Fork) *
 	metrics := metrics.Noop
 
 	var err error
-	res.mempool, err = mempool.New("mempool", registerer, func() {})
+	res.mempool, err = mempool.New("mempool", registerer)
 	if err != nil {
 		panic(fmt.Errorf("failed to create mempool: %w", err))
 	}

--- a/vms/platformvm/block/executor/manager.go
+++ b/vms/platformvm/block/executor/manager.go
@@ -34,7 +34,7 @@ type Manager interface {
 	// Returns the ID of the most recently accepted block.
 	LastAccepted() ids.ID
 
-	SetPreference(blkID ids.ID) (updated bool)
+	SetPreference(blkID ids.ID)
 	Preferred() ids.ID
 
 	GetBlock(blkID ids.ID) (snowman.Block, error)
@@ -110,10 +110,8 @@ func (m *manager) NewBlock(blk block.Block) snowman.Block {
 	}
 }
 
-func (m *manager) SetPreference(blkID ids.ID) bool {
-	updated := m.preferred != blkID
+func (m *manager) SetPreference(blkID ids.ID) {
 	m.preferred = blkID
-	return updated
 }
 
 func (m *manager) Preferred() ids.ID {

--- a/vms/platformvm/block/executor/manager_test.go
+++ b/vms/platformvm/block/executor/manager_test.go
@@ -79,10 +79,9 @@ func TestManagerSetPreference(t *testing.T) {
 	manager := &manager{
 		preferred: initialPreference,
 	}
-	require.False(manager.SetPreference(initialPreference))
+	require.Equal(initialPreference, manager.Preferred())
 
 	newPreference := ids.GenerateTestID()
-	require.True(manager.SetPreference(newPreference))
-	require.False(manager.SetPreference(newPreference))
-	require.True(manager.SetPreference(initialPreference))
+	manager.SetPreference(newPreference)
+	require.Equal(newPreference, manager.Preferred())
 }

--- a/vms/platformvm/block/executor/proposal_block_test.go
+++ b/vms/platformvm/block/executor/proposal_block_test.go
@@ -1372,7 +1372,7 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 	blk := env.blkManager.NewBlock(statelessBlk)
 	require.NoError(blk.Verify(context.Background()))
 	require.NoError(blk.Accept(context.Background()))
-	require.True(env.blkManager.SetPreference(statelessBlk.ID()))
+	env.blkManager.SetPreference(statelessBlk.ID())
 
 	// Should be current
 	staker, err := env.state.GetCurrentValidator(constants.PrimaryNetworkID, nodeID)
@@ -1405,7 +1405,7 @@ func TestAddValidatorProposalBlock(t *testing.T) {
 		blk = env.blkManager.NewBlock(statelessBlk)
 		require.NoError(blk.Verify(context.Background()))
 		require.NoError(blk.Accept(context.Background()))
-		require.True(env.blkManager.SetPreference(statelessBlk.ID()))
+		env.blkManager.SetPreference(statelessBlk.ID())
 	}
 
 	env.clk.Set(validatorEndTime)

--- a/vms/platformvm/block/executor/rejector_test.go
+++ b/vms/platformvm/block/executor/rejector_test.go
@@ -120,7 +120,7 @@ func TestRejectBlock(t *testing.T) {
 			blk, err := tt.newBlockFunc()
 			require.NoError(err)
 
-			mempool, err := mempool.New("", prometheus.NewRegistry(), func() {})
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			state := state.NewMockState(ctrl)
 			blkIDToState := map[ids.ID]*blockState{

--- a/vms/platformvm/block/executor/verifier_test.go
+++ b/vms/platformvm/block/executor/verifier_test.go
@@ -75,7 +75,7 @@ func newTestVerifier(t testing.TB, c testVerifierConfig) *verifier {
 		c.ValidatorFeeConfig = genesis.LocalParams.ValidatorFeeConfig
 	}
 
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 
 	var (
@@ -454,7 +454,7 @@ func TestVerifierVisitCommitBlock(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -528,7 +528,7 @@ func TestVerifierVisitAbortBlock(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -603,7 +603,7 @@ func TestVerifyUnverifiedParent(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 
@@ -674,7 +674,7 @@ func TestBanffAbortBlockTimestampChecks(t *testing.T) {
 
 			// Create mocked dependencies.
 			s := state.NewMockState(ctrl)
-			mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			parentID := ids.GenerateTestID()
 			parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -775,7 +775,7 @@ func TestBanffCommitBlockTimestampChecks(t *testing.T) {
 
 			// Create mocked dependencies.
 			s := state.NewMockState(ctrl)
-			mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+			mempool, err := mempool.New("", prometheus.NewRegistry())
 			require.NoError(err)
 			parentID := ids.GenerateTestID()
 			parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -844,7 +844,7 @@ func TestVerifierVisitApricotStandardBlockWithProposalBlockParent(t *testing.T) 
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -901,7 +901,7 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 
 	// Create mocked dependencies.
 	s := state.NewMockState(ctrl)
-	mempool, err := mempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := mempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	parentID := ids.GenerateTestID()
 	parentStatelessBlk := block.NewMockBlock(ctrl)
@@ -953,8 +953,6 @@ func TestVerifierVisitBanffStandardBlockWithProposalBlockParent(t *testing.T) {
 	err = verifier.BanffStandardBlock(blk)
 	require.ErrorIs(err, state.ErrMissingParentState)
 }
-
-func noopNotify() {}
 
 func TestVerifierVisitApricotCommitBlockUnexpectedParentState(t *testing.T) {
 	require := require.New(t)

--- a/vms/platformvm/network/gossip.go
+++ b/vms/platformvm/network/gossip.go
@@ -73,20 +73,17 @@ func newGossipMempool(
 	minTargetElements int,
 	targetFalsePositiveProbability,
 	resetFalsePositiveProbability float64,
-	notifyBuildBlock func(),
 ) (*gossipMempool, error) {
 	bloom, err := gossip.NewBloomFilter(registerer, "mempool_bloom_filter", minTargetElements, targetFalsePositiveProbability, resetFalsePositiveProbability)
 	return &gossipMempool{
-		notifyBuildBlock: notifyBuildBlock,
-		Mempool:          mempool,
-		log:              log,
-		txVerifier:       txVerifier,
-		bloom:            bloom,
+		Mempool:    mempool,
+		log:        log,
+		txVerifier: txVerifier,
+		bloom:      bloom,
 	}, err
 }
 
 type gossipMempool struct {
-	notifyBuildBlock func() // Notifies when a transaction is added to the mempool
 	mempool.Mempool[*txs.Tx]
 	log        logging.Logger
 	txVerifier TxVerifier
@@ -140,13 +137,6 @@ func (g *gossipMempool) Add(tx *txs.Tx) error {
 			return true
 		})
 	}
-
-	if g.Mempool.Len() == 0 {
-		return nil
-	}
-
-	g.notifyBuildBlock()
-
 	return nil
 }
 

--- a/vms/platformvm/network/gossip_test.go
+++ b/vms/platformvm/network/gossip_test.go
@@ -20,8 +20,6 @@ import (
 
 var errFoo = errors.New("foo")
 
-func noopNotify() {}
-
 // Add should error if verification errors
 func TestGossipMempoolAddVerificationError(t *testing.T) {
 	require := require.New(t)
@@ -31,7 +29,7 @@ func TestGossipMempoolAddVerificationError(t *testing.T) {
 		TxID: txID,
 	}
 
-	mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	txVerifier := testTxVerifier{err: errFoo}
 
@@ -43,7 +41,6 @@ func TestGossipMempoolAddVerificationError(t *testing.T) {
 		testConfig.ExpectedBloomFilterElements,
 		testConfig.ExpectedBloomFilterFalsePositiveProbability,
 		testConfig.MaxBloomFilterFalsePositiveProbability,
-		noopNotify,
 	)
 	require.NoError(err)
 
@@ -56,7 +53,7 @@ func TestGossipMempoolAddVerificationError(t *testing.T) {
 func TestMempoolDuplicate(t *testing.T) {
 	require := require.New(t)
 
-	testMempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+	testMempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 	txVerifier := testTxVerifier{}
 
@@ -75,7 +72,6 @@ func TestMempoolDuplicate(t *testing.T) {
 		testConfig.ExpectedBloomFilterElements,
 		testConfig.ExpectedBloomFilterFalsePositiveProbability,
 		testConfig.MaxBloomFilterFalsePositiveProbability,
-		noopNotify,
 	)
 	require.NoError(err)
 
@@ -95,7 +91,7 @@ func TestGossipAddBloomFilter(t *testing.T) {
 	}
 
 	txVerifier := testTxVerifier{}
-	mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+	mempool, err := pmempool.New("", prometheus.NewRegistry())
 	require.NoError(err)
 
 	gossipMempool, err := newGossipMempool(
@@ -106,7 +102,6 @@ func TestGossipAddBloomFilter(t *testing.T) {
 		testConfig.ExpectedBloomFilterElements,
 		testConfig.ExpectedBloomFilterFalsePositiveProbability,
 		testConfig.MaxBloomFilterFalsePositiveProbability,
-		noopNotify,
 	)
 	require.NoError(err)
 

--- a/vms/platformvm/network/network.go
+++ b/vms/platformvm/network/network.go
@@ -52,7 +52,6 @@ func New(
 	signer warp.Signer,
 	registerer prometheus.Registerer,
 	config config.Network,
-	notifyBuildBlock func(),
 ) (*Network, error) {
 	p2pNetwork, err := p2p.NewNetwork(log, appSender, registerer, "p2p")
 	if err != nil {
@@ -84,7 +83,6 @@ func New(
 		config.ExpectedBloomFilterElements,
 		config.ExpectedBloomFilterFalsePositiveProbability,
 		config.MaxBloomFilterFalsePositiveProbability,
-		notifyBuildBlock,
 	)
 	if err != nil {
 		return nil, err

--- a/vms/platformvm/network/network_test.go
+++ b/vms/platformvm/network/network_test.go
@@ -72,7 +72,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "mempool has transaction",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				require.NoError(t, mempool.Add(&txs.Tx{Unsigned: &txs.BaseTx{}}))
 				return mempool
@@ -86,7 +86,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "transaction marked as dropped in mempool",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				mempool.MarkDropped(ids.Empty, errTest)
 				return mempool
@@ -101,7 +101,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx dropped",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),
@@ -116,7 +116,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx too big",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),
@@ -135,7 +135,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "tx conflicts",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
 				tx := &txs.Tx{
@@ -177,7 +177,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "mempool full",
 			mempool: func() *pmempool.Mempool {
-				m, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				m, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 
 				for i := 0; i < 1024; i++ {
@@ -204,7 +204,7 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 		{
 			name: "happy path",
 			mempool: func() *pmempool.Mempool {
-				mempool, err := pmempool.New("", prometheus.NewRegistry(), noopNotify)
+				mempool, err := pmempool.New("", prometheus.NewRegistry())
 				require.NoError(t, err)
 				return mempool
 			}(),
@@ -238,7 +238,6 @@ func TestNetworkIssueTxFromRPC(t *testing.T) {
 				nil,
 				prometheus.NewRegistry(),
 				testConfig,
-				noopNotify,
 			)
 			require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

This migrates the platformVM to utilize `WaitForEvent` rather than implementing the timer logic.

## How this works

Used the existing timer logic but moved it into the `WaitForEvent` call stack.

## How this was tested

Existing CI